### PR TITLE
Make compatible with django 1.11

### DIFF
--- a/test_without_migrations/management/commands/test.py
+++ b/test_without_migrations/management/commands/test.py
@@ -20,7 +20,12 @@ class DisableMigrations(object):
         return True
 
     def __getitem__(self, item):
-        return "notmigrations"
+        # django 1.9 takes None, 1.7/8 has an error here, so use a dummy value
+        # 1.11+ always actually imports the module, so we can't use the dummy there
+        if DJANGO_VERSION < (1, 9):
+            return 'notmigrations'
+        else:
+            return None
 
 
 class Command(TestCommand):


### PR DESCRIPTION
Django 1.11+ actually checks for a valid module, so 'notmigrations' is no longer valid. 